### PR TITLE
#325 - version bump of google-api-client-appengine to 1.23.0

### DIFF
--- a/bookshelf-standard/3-binary-data/pom.xml
+++ b/bookshelf-standard/3-binary-data/pom.xml
@@ -72,7 +72,7 @@ Copyright 2016 Google Inc.
         <dependency>
           <groupId>com.google.api-client</groupId>
           <artifactId>google-api-client-appengine</artifactId>
-          <version>1.21.0</version>
+          <version>1.23.0</version>
         </dependency>
       </dependencies>
     </profile>


### PR DESCRIPTION
fix for https://github.com/GoogleCloudPlatform/getting-started-java/issues/325